### PR TITLE
Fix mini badge text align issue only in Firefox (Fix #32)

### DIFF
--- a/api/views.py
+++ b/api/views.py
@@ -549,8 +549,8 @@ def generate_badge_mini(request):
     </defs>
     <rect width="40" height="20" x="70" y="0" rx="3" ry="3" class="background"/>
     <rect width="75" height="20" clip-path="url(#round-corner)" class="gray-area"/>
-    <text text-anchor="middle" alignment-baseline="middle" transform="translate(37.5, 11)">solved.ac</text>
-    <text class="tier" text-anchor="middle" alignment-baseline="middle" transform="translate(92, 11)">{tier_title}{tier_rank}</text>
+    <text text-anchor="middle" alignment-baseline="middle" dominant-baseline="middle" transform="translate(37.5, 11)">solved.ac</text>
+    <text class="tier" text-anchor="middle" alignment-baseline="middle" dominant-baseline="middle" transform="translate(92, 11)">{tier_title}{tier_rank}</text>
 
 
 </svg>


### PR DESCRIPTION
<table>
<tr>
	<td></td>
	<td>Before</td>
	<td>After</td>
<tr>
	<td>Chrome</td>
	<td>
<img width="612" alt="Screenshot 2022-12-13 at 17 53 27" src="https://user-images.githubusercontent.com/47936709/207274326-f26c4eb2-90df-4225-814d-721b434e59e4.png">
</td>
	<td>
<img width="612" alt="Screenshot 2022-12-13 at 17 53 36" src="https://user-images.githubusercontent.com/47936709/207274404-1f201845-e7b8-49f5-b90c-67038d868806.png">
</td>
<tr>
	<td>Firefox</td>
	<td>
<img width="562" alt="Screenshot 2022-12-13 at 17 52 15" src="https://user-images.githubusercontent.com/47936709/207274492-c3800dfb-0083-4eb6-b7a1-cd41f13fd8ee.png">
</td>
	<td>
<img width="562" alt="Screenshot 2022-12-13 at 17 52 41" src="https://user-images.githubusercontent.com/47936709/207274534-476b4600-79bf-43f4-a156-976c4d5319a2.png">
</td>
</table>

Tested version
- Mac Firefox 108.0b9
- Mac Chrome 108.0.5359.98