### PR TITLE
Fix deployment boot failure by upgrading Gunicorn to 22.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ authors = ["Jaeyeol Lee <rijgndqw012@gmail.com>"]
 python = "^3.7"
 django = "^3.1"
 requests = "^2.24.0"
-gunicorn = "^20.0.4"
+gunicorn = "^22.0.0"
 httpx = { extras = ["http2"], version = "^0.23.0" }
 curl_cffi = "^0.5.5"
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ asgiref==3.2.10
 certifi==2020.6.20
 chardet==3.0.4
 django==3.1
-gunicorn==20.0.4
+gunicorn==22.0.0
 idna==2.10
 pytz==2020.1
 requests==2.24.0


### PR DESCRIPTION
### 개요
Cloudflare 403 대응을 위해 curl_cffi를 도입한 이후, 배포 환경에서 애플리케이션 부팅이 실패하는 문제가 발생했습니다.  
원인 분석 결과, Gunicorn 구버전과 최신 setuptools 조합의 호환성 이슈로 확인되었습니다.

### 원인
- 배포 시 Gunicorn 시작 단계에서 ModuleNotFoundError: No module named pkg_resources 발생
- Gunicorn 20.0.4가 pkg_resources 경로에 의존
- 최신 setuptools 환경에서 해당 경로와의 호환성 문제로 부팅 실패

### 변경 사항
- requirements.txt에서 Gunicorn 버전을 20.0.4에서 22.0.0으로 업데이트
- pyproject.toml에서 Gunicorn 버전 제약을 ^20.0.4에서 ^22.0.0으로 업데이트
- curl_cffi 기반 Solved.ac API 호출 로직은 변경 없음

### 검증
- pip install -r requirements.txt 성공
- python manage.py check 통과
- gunicorn mazassumnida.wsgi --check-config 통과
- 최신 setuptools 환경에서 Gunicorn 부팅 검증 완료

### 영향 범위
- 런타임 서버 프로세스 의존성(Gunicorn) 버전만 변경
- API/배지 렌더링 로직 영향 없음

### 기대 효과
- 배포 시 WSGI 부팅 실패 해소
- 서비스 기동 안정성 개선